### PR TITLE
Remove unused package dependencies which aren't buildable with ghc-8.2

### DIFF
--- a/eqsat.cabal
+++ b/eqsat.cabal
@@ -40,8 +40,6 @@ library
                         , aeson                       >= 1.0   && < 1.3
                         , binary                      >= 0.8   && < 0.9
                         , bytestring                  >= 0.10  && < 0.11
-                        , cborg                       >= 0.2   && < 0.3
-                        , cborg-json                  >= 0.2   && < 0.3
                         , cereal                      >= 0.5   && < 0.6
                         , containers                  >= 0.5   && < 0.6
                         , contravariant               >= 1.4   && < 1.5
@@ -63,20 +61,10 @@ library
                         , prettyprinter               >= 1.1   && < 1.2
                         , prettyprinter-ansi-terminal >= 1.1   && < 1.2
                         , primitive                   >= 0.6   && < 0.7
-                        , QuickCheck                  >= 2.9   && < 2.10
-                        , quickcheck-instances        >= 0.3   && < 0.4
-                        , sbv                         >= 7.5   && < 7.7
+                        , sbv                         >= 7.7   && < 7.8
                         , serialise                   >= 0.2   && < 0.3
-                        , smallcheck                  >= 1.1   && < 1.2
                         , system-filepath             >= 0.4   && < 0.5
-                        , tasty                       >= 0.11  && < 0.12
-                        , tasty-hedgehog              >= 0.1   && < 0.2
-                        , tasty-html                  >= 0.4   && < 0.5
-                        , tasty-hunit                 >= 0.9   && < 0.10
-                        , tasty-lens                  >= 0.3   && < 0.4
-                        , tasty-quickcheck            >= 0.8   && < 0.9
-                        , tasty-smallcheck            >= 0.8   && < 0.9
-                        , template-haskell            >= 2.9   && < 2.12
+                        , template-haskell            >= 2.9   && < 2.14
                         , text                        >= 1.2   && < 1.3
                         , transformers                >= 0.4   && < 0.6
                         , unexceptionalio             >= 0.3   && < 0.4
@@ -98,7 +86,7 @@ library
                         , EqSat.TermIndex.DiscriminationNet
                         , EqSat.TermIndex.SubstitutionTree
                         , EqSat.Errors.CheckEquationError
-                        , EqSat.Internal.Compact
+--                        , EqSat.Internal.Compact
                         , EqSat.Internal.MStack
                         , EqSat.Internal.MHashSet
                         , EqSat.Internal.MHashMap

--- a/eqsat.cabal
+++ b/eqsat.cabal
@@ -40,6 +40,8 @@ library
                         , aeson                       >= 1.0   && < 1.3
                         , binary                      >= 0.8   && < 0.9
                         , bytestring                  >= 0.10  && < 0.11
+                        , cborg                       >= 0.2   && < 0.3
+                        , cborg-json                  >= 0.2   && < 0.3
                         , cereal                      >= 0.5   && < 0.6
                         , containers                  >= 0.5   && < 0.6
                         , contravariant               >= 1.4   && < 1.5
@@ -86,7 +88,7 @@ library
                         , EqSat.TermIndex.DiscriminationNet
                         , EqSat.TermIndex.SubstitutionTree
                         , EqSat.Errors.CheckEquationError
---                        , EqSat.Internal.Compact
+                        , EqSat.Internal.Compact
                         , EqSat.Internal.MStack
                         , EqSat.Internal.MHashSet
                         , EqSat.Internal.MHashMap

--- a/library/EqSat/Internal/Compact.hs
+++ b/library/EqSat/Internal/Compact.hs
@@ -82,11 +82,9 @@ cborEncoder f = MkEncoder (f .> CBOR.Write.toLazyByteString)
 
 -- | FIXME: doc
 #if __GLASGOW_HASKELL__ >= 802
-newtype Compact a
-  = MkCompact (Compact.Compact a)
+type Compact a = Compact.Compact a
 #else
-newtype Compact a
-  = MkCompact a
+type Compact a = a
 #endif
 
 -- | FIXME: doc
@@ -126,7 +124,7 @@ unsafeReadCompact
   :: (Typeable a)
   => Decoder a
   -> FilePath
-  -> IO (Either (PP.Doc Void) (Compact a))
+  -> IO (Either String (Compact a))
 
 -- | FIXME: doc
 hPutCompact
@@ -145,19 +143,19 @@ hUnsafeGetCompact
 
 #if __GLASGOW_HASKELL__ >= 802
 
-compact               = coerce Compact.compact
-compactWithSharing    = coerce Compact.compactWithSharing
-compactAdd            = coerce Compact.compactAdd
-compactAddWithSharing = coerce Compact.compactAddWithSharing
-compactSized          = coerce Compact.compactSized
-getCompact            = coerce Compact.getCompact
-isCompact             = coerce Compact.isCompact
-compactSize           = coerce Compact.compactSize
+compact               = Compact.compact
+compactWithSharing    = Compact.compactWithSharing
+compactAdd            = Compact.compactAdd
+compactAddWithSharing = Compact.compactAddWithSharing
+compactSized          = Compact.compactSized
+getCompact            = Compact.getCompact
+isCompact             = Compact.isCompact
+compactSize           = Compact.compactSize
 
-writeCompact          = const (coerce Compact.writeCompact)
-unsafeReadCompact     = const (coerce Compact.unsafeReadCompact)
-hPutCompact           = const (coerce Compact.hPutCompact)
-hUnsafeGetCompact     = const (coerce Compact.hUnsafeGetCompact)
+writeCompact          = const Compact.writeCompact
+unsafeReadCompact     = const Compact.unsafeReadCompact
+hPutCompact           = const Compact.hPutCompact
+hUnsafeGetCompact     = const Compact.hUnsafeGetCompact
 
 #else
 


### PR DESCRIPTION
The EqSat.Internal.Compact module doesn't build with ghc-8.2 but that module isn't used. Quite a few unused dependencies also doesn't build with newer versions of GHC.